### PR TITLE
Update {{ stage_name }}.qmd

### DIFF
--- a/src/dso/templates/stage/quarto/src/{{ stage_name }}.qmd
+++ b/src/dso/templates/stage/quarto/src/{{ stage_name }}.qmd
@@ -1,12 +1,12 @@
 ```{r}
-#| label: load libraries
+#| label: load_libraries
 
 require(conflicted)
 require(dso)
 ```
 
 ```{r}
-#| label: read params
+#| label: read_params
 # read_params sets the stage directory, runs 'dso compile-config'
 # and loads params defined in the 'dvc.yaml' 'params' section of the stage
 
@@ -14,7 +14,7 @@ params <- read_params("{{ stage_path }}")
 ```
 
 ```{r}
-#| label: Obtain files relative to stage directory
+#| label: obtain_files_relative_to_stage_dir
 
 # stage_here locates your files relative to the stage path set in read_params
 # e.g.

--- a/src/dso/templates/stage/quarto/src/{{ stage_name }}.qmd
+++ b/src/dso/templates/stage/quarto/src/{{ stage_name }}.qmd
@@ -1,14 +1,22 @@
 ```{r}
-library(conflicted)
-library(dso)
+#| label: load libraries
+
+require(conflicted)
+require(dso)
 ```
 
 ```{r}
-# Set stage dir, compile and load params
+#| label: read params
+# read_params sets the stage directory, runs 'dso compile-config'
+# and loads params defined in the 'dvc.yaml' 'params' section of the stage
+
 params <- read_params("{{ stage_path }}")
 ```
 
 ```{r}
-# Obtain files relative to stage directory, e.g.
+#| label: Obtain files relative to stage directory
+
+# stage_here locates your files relative to the stage path set in read_params
+# e.g.
 samplesheet <- readr::read_csv(stage_here(params$samplesheet))
 ```


### PR DESCRIPTION
Added descriptive comments to clear up the functionality of read_params and stage_here for beginners with dso.

It is important to mention the relation between `read_params` and `dvc.yaml` for beginners to clear up that parameters have to be specified there.

