### PR TITLE
added option --all to compile-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixes
 
 -  Exit gracefully when aborting template selections.
+-  added `-all` option `dso compile-config` to compile all configs in project
 
 ## v0.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning][].
 ### Fixes
 
 -  Exit gracefully when aborting template selections.
--  added `-all` option `dso compile-config` to compile all configs in project
+
+### Additions
+
+-  Added `--all` option to `dso compile-config` to compile all configs in project
 
 ## v0.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Additions
 
--  Added `--all` option to `dso compile-config` to compile all configs in project
+-  Added `--all` option to `dso compile-config` to compile all configs in project ([#137](https://github.com/Boehringer-Ingelheim/dso/pull/137/files))
 
 ## v0.13.2
 

--- a/src/dso/cli/__init__.py
+++ b/src/dso/cli/__init__.py
@@ -24,8 +24,15 @@ click.rich_click.USE_MARKDOWN = True
 
 
 @click.command(name="compile-config")
+@click.option(
+    "--all",
+    is_flag=True,
+    type=bool,
+    default=False,
+    help="Compile all configs in the project",
+)
 @click.argument("args", nargs=-1)
-def dso_compile_config(args):
+def dso_compile_config(all, args):
     """Compile params.in.yaml into params.yaml using Jinja2 templating and resolving recursive templates.
 
     If passing no arguments, configs will be resolved for the current working directory (i.e. all parent configs,
@@ -34,7 +41,11 @@ def dso_compile_config(args):
     """
     from dso._compile_config import compile_all_configs
 
-    if not len(args):
+    if all and not len(args):
+        paths = [get_project_root(Path.cwd())]
+    elif all:
+        paths = [get_project_root(Path(x)) for x in args]
+    elif not len(args):
         paths = [Path.cwd()]
     else:
         paths = [Path(x) for x in args]


### PR DESCRIPTION
Added an --all option to compile-config to compile all configs in the project root 

-   [x] CHANGELOG.md updated
-   [x] Tested

