### PR TITLE
add info to bash template

### DIFF
--- a/src/dso/templates/stage/bash/dvc.yaml
+++ b/src/dso/templates/stage/bash/dvc.yaml
@@ -11,4 +11,8 @@ stages:
         # add bash code here
         mkdir -p output && echo "Hello World" > output/hello.txt
 
+        # For more complex shell logic like variables or loops
+        # add a script src/{{ name }}.sh and execute from here:
+        # sh src/{{ name }}.sh
+ 
         EOF


### PR DESCRIPTION
`dvc` uses `subprocess.Popen` to execute `cmd` which cannot take any complex shell logic. 

Unfortunately, when using more complex shell logic this will not lead to an error, but variables not being assigned. Hence, to prevent users to try to add complex logic, info was added that complex shell logic needs to be executed in a separate bash script. 

