### PR TITLE
DSO compatibility on windows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -55,6 +55,16 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install pandoc
 
+      - name: Install Jupyter + ipykernel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jupyter ipykernel nbformat nbclient
+          python -m ipykernel install --user --name=python3
+
+      - name: Set QUARTO_PYTHON (cross-platform)
+        shell: bash
+        run: echo "QUARTO_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
+
       - name: "Install DSO"
         run: pip install  ${{ matrix.pip-flags }} '.[test]'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,8 +10,8 @@ on:
       - "docs/**"
 
 jobs:
-  unit_tests_linux:
-    name: ${{ matrix.name }} Python ${{ matrix.python }}
+  unit_tests:
+    name: ${{ matrix.name }} Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,11 +25,15 @@ jobs:
             python-version: "3.13"
             pip-flags: "--pre"
             name: PRE-RELEASE DEPENDENCIES
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.13"
 
     env:
-      # GitHub currently has 4 cores available for Linux runners
+      # GitHub has 4 cores for Linux, 2 cores for Windows runners
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-      worker_cores: 4
+      worker_cores: ${{ matrix.os == 'ubuntu-latest' && 4 || 2 }}
 
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +47,13 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
-      - name: Install libgit2 header files for libgit2 & pandoc for testing purposes
+      - name: Install libgit2 header files for libgit2 & pandoc for testing purposes (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y libgit2-dev pandoc
+
+      - name: Install pandoc for testing purposes (Windows)
+        if: runner.os == 'Windows'
+        run: choco install pandoc
 
       - name: "Install DSO"
         run: pip install  ${{ matrix.pip-flags }} '.[test]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,81 +8,111 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## v0.13.4
+
+### Added
+
+- Windows-aware parsing of the `DSO_TEMPLATE_LIBRARIES` environment variable. You can now include absolute Windows paths with drive letters (e.g. `D:\my\templates`) without breaking the split logic.
+  - **Files:** `src/dso/_templates.py`
+
+### Changed
+
+- Compiled path separator behavior in `params.yaml`:
+  - On **Windows**, `!path` values now compile to **backslashes** (e.g. `test\test.csv`).
+  - On **Linux/macOS**, `!path` values remain **forward slashes**.
+  - Authoring guidance is unchanged: keep **forward slashes** in `params.in.yaml`; compilation maps them appropriately for the OS.
+  - **Files:** `src/dso/_compile_config.py`
+- Template rendering now writes **UTF-8** with **LF** newlines and guarantees a final newline in generated files. This removes `pre-commit` “mixed line ending” failures on Windows.
+  - **Files:** `src/dso/_templates.py`
+- Upward search for project files is now robust across platforms: it cleanly stops at drive/UNC roots on Windows and at filesystem roots on POSIX.
+  - **Files:** `src/dso/_util.py`
+
+### Fixed
+
+- Eliminated `RecursionError` in `find_in_parent` when traversing above Windows drive or UNC roots.
+  - **Files:** `src/dso/_util.py`
+- Resolved `pre-commit` failures due to mixed line endings in files created from templates by enforcing LF on write (with UTF-8 and trailing newline).
+  - **Files:** `src/dso/_templates.py`
+- Made tests platform-independent for compiled paths and file I/O:
+  - Path assertions use OS-native normalization rather than hard-coded `/`.
+  - Test file reads/writes use UTF-8.
+  - **Files:** `tests/test_compile_config.py` (and related tests adjusted where needed)
+
 ## v0.13.3
 
 ### Fixes
 
--  Fix how the `output` directory in stages is treated. Previously, the `output` directory was not
+- Fix how the `output` directory in stages is treated. Previously, the `output` directory was not
    part of of the stage template. Instead it got added dynamically during `dso exec quarto` and removed
    again in case it was empty. This could lead to failures of `dvc repro`, because `dvc` removed the `output`
    directory on repro, expecting it to be recreated by the script. Now, the `output` directory is part of the
    stage template, and a `mkdir -p output` is included in the stage command, ensuring that the directory will
    always be created ([#144](https://github.com/Boehringer-Ingelheim/dso/pull/144)).
--  Exit gracefully when aborting template selections ([#134](https://github.com/Boehringer-Ingelheim/dso/pull/134)).
--  Make sure watermarking doesn't modify external images inplace ([#140](https://github.com/Boehringer-Ingelheim/dso/pull/140)).
--  Do not exclude `meta.yaml` from templates. We leave it up to the templates to .gitignore them ([#142](https://github.com/Boehringer-Ingelheim/dso/pull/142)).
--  Fix that template libraries appeared in random order in `dso create` ([#145](https://github.com/Boehringer-Ingelheim/dso/pull/145)).
+- Exit gracefully when aborting template selections ([#134](https://github.com/Boehringer-Ingelheim/dso/pull/134)).
+- Make sure watermarking doesn't modify external images inplace ([#140](https://github.com/Boehringer-Ingelheim/dso/pull/140)).
+- Do not exclude `meta.yaml` from templates. We leave it up to the templates to .gitignore them ([#142](https://github.com/Boehringer-Ingelheim/dso/pull/142)).
+- Fix that template libraries appeared in random order in `dso create` ([#145](https://github.com/Boehringer-Ingelheim/dso/pull/145)).
 
 ### Additions
 
--  Added `--all` option to `dso compile-config` to compile all configs in project ([#137](https://github.com/Boehringer-Ingelheim/dso/pull/137/files))
+- Added `--all` option to `dso compile-config` to compile all configs in project ([#137](https://github.com/Boehringer-Ingelheim/dso/pull/137/files))
 
 ### Chore
 
--  Drop support for Python 3.10 in accordance with SPEC0 ([#140](https://github.com/Boehringer-Ingelheim/dso/pull/140)).
+- Drop support for Python 3.10 in accordance with SPEC0 ([#140](https://github.com/Boehringer-Ingelheim/dso/pull/140)).
 
 ## v0.13.2
 
 ### Fixes
 
--   Rename filenames with a jinja2 variable in the default template library to match the new
+- Rename filenames with a jinja2 variable in the default template library to match the new
     variables names that were introduced in `v0.13.0` ([#120](https://github.com/Boehringer-Ingelheim/dso/pull/120)).
 
 ## v0.13.1
 
 ### Fixes
 
--   Exclude `meta.yaml` at the root of a stage/folder/project template. `meta.yaml` files can be used
+- Exclude `meta.yaml` at the root of a stage/folder/project template. `meta.yaml` files can be used
     to define metadata of templates, but it is currently not used by `dso` ([#119](https://github.com/Boehringer-Ingelheim/dso/pull/119)).
 
 ## v0.13.0
 
 ### Additions
 
--   Add `dso status` and `dso push` as a wrappers for the respective `dvc` commands ([#114](https://github.com/Boehringer-Ingelheim/dso/pull/114)).
--   Add support for custom template libraries. Additional template libraries can be configured via
+- Add `dso status` and `dso push` as a wrappers for the respective `dvc` commands ([#114](https://github.com/Boehringer-Ingelheim/dso/pull/114)).
+- Add support for custom template libraries. Additional template libraries can be configured via
     the `DSO_TEMPLATE_LIBRARIES` environment variable. As part of this PR, the `dso init` and `dso create` commands
     were rewritten. ([#117](https://github.com/Boehringer-Ingelheim/dso/pull/117))
 
 ### Template updates
 
--   Add `_quarto.yml` to "init" template `.gitignore` ([#115](https://github.com/Boehringer-Ingelheim/dso/pull/115))
+- Add `_quarto.yml` to "init" template `.gitignore` ([#115](https://github.com/Boehringer-Ingelheim/dso/pull/115))
 
 ### Chore
 
--   Update repository template to cookiecutter-scverse v0.5.0 ([#111](https://github.com/Boehringer-Ingelheim/dso/pull/111)).
+- Update repository template to cookiecutter-scverse v0.5.0 ([#111](https://github.com/Boehringer-Ingelheim/dso/pull/111)).
 
 ### Documentation
 
--   Show how to enable shell-completion for `dso` ([#116](https://github.com/Boehringer-Ingelheim/dso/pull/116))
+- Show how to enable shell-completion for `dso` ([#116](https://github.com/Boehringer-Ingelheim/dso/pull/116))
 
 ## v0.12.2
 
 ### Fixes
 
--   Empty folders were not created as expected in stage templates ([#107](https://github.com/Boehringer-Ingelheim/dso/pull/107))
+- Empty folders were not created as expected in stage templates ([#107](https://github.com/Boehringer-Ingelheim/dso/pull/107))
 
 ### Documentation
 
--   Restructure into user guides and tutorials section ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
--   Add tutorial on "how to work on existing DSO project" ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
--   Add tutorial on "how to convert an existing project into DSO format" ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
+- Restructure into user guides and tutorials section ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
+- Add tutorial on "how to work on existing DSO project" ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
+- Add tutorial on "how to convert an existing project into DSO format" ([#104](https://github.com/Boehringer-Ingelheim/dso/pull/104))
 
 ## v0.12.1
 
 ### Fixes
 
--   Temporarily disable linting, because of its slow speed with only one rule implemented. See #70, #5, and #66
+- Temporarily disable linting, because of its slow speed with only one rule implemented. See #70, #5, and #66
     on GitHub for more information ([#103](https://github.com/Boehringer-Ingelheim/dso/pull/103)).
 
 ## v0.12.0
@@ -100,162 +130,162 @@ dso init will re-add all files from the project template that are missing from y
 
 ### Template updates
 
--   Update `.pre-commit-config.yaml`, removing unnecessary hooks ([#99](https://github.com/Boehringer-Ingelheim/dso/pull/99)).
+- Update `.pre-commit-config.yaml`, removing unnecessary hooks ([#99](https://github.com/Boehringer-Ingelheim/dso/pull/99)).
 
 ### New features
 
--   Add `dso pull` command, a wrapper around `dso compile-config` + `dvc pull` ([#99](https://github.com/Boehringer-Ingelheim/dso/pull/99))
--   Add templates for Python stages (`quarto_py`, `quarto_ipynb`) ([#98](https://github.com/Boehringer-Ingelheim/dso/pull/98)).
+- Add `dso pull` command, a wrapper around `dso compile-config` + `dvc pull` ([#99](https://github.com/Boehringer-Ingelheim/dso/pull/99))
+- Add templates for Python stages (`quarto_py`, `quarto_ipynb`) ([#98](https://github.com/Boehringer-Ingelheim/dso/pull/98)).
 
 ### Documentation
 
--   Update documentation, finalizing the most important sections of the user guide.
+- Update documentation, finalizing the most important sections of the user guide.
 
 ## v0.11.0
 
 ### Template updates
 
--   Single `.gitignore` file per stage. Content of input/output/report folders is ignored. These folders
+- Single `.gitignore` file per stage. Content of input/output/report folders is ignored. These folders
     do not contain a separate `.gitignore` anymore. This means empty folders won't be tracked by git, but
     this solves issues with dvc refusing to track the output folder because it is already partly tracked by git ([#73](https://github.com/Boehringer-Ingelheim/dso/pull/73)).
 
 ### Fixes
 
--   Do not change the configuration of the root logger, only the `dso` logger. Changing the root logger
+- Do not change the configuration of the root logger, only the `dso` logger. Changing the root logger
     had side-effects on other libraries when importing `dso` in Python ([#80](https://github.com/Boehringer-Ingelheim/dso/pull/80)).
 
 ### New features
 
--   Paths in `params.in.yaml` files declared with `!path` can now be compiled to absolute instead of relative paths ([#78](https://github.com/Boehringer-Ingelheim/dso/pull/78)).
--   Python API that mirrors `dso-r` functionality (e.g. to be used from Jupyter notebooks) ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
--   `dso exec quarto` automatically creates an `output` directory in the stage if it doesn't exist. If it doesn't contain any file,
+- Paths in `params.in.yaml` files declared with `!path` can now be compiled to absolute instead of relative paths ([#78](https://github.com/Boehringer-Ingelheim/dso/pull/78)).
+- Python API that mirrors `dso-r` functionality (e.g. to be used from Jupyter notebooks) ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
+- `dso exec quarto` automatically creates an `output` directory in the stage if it doesn't exist. If it doesn't contain any file,
     it will be removed again after completion ([#73](https://github.com/Boehringer-Ingelheim/dso/pull/73)).
 
 ### Documentation
 
--   Various documentation updates, working towards the first public version of the docs.
+- Various documentation updates, working towards the first public version of the docs.
 
 ### Chore
 
--   Refactor CLI into separate module ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
--   Defer imports in CLI until they are actually needed to speed up CLI ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
--   Make all modules explicitly private that are not part of the public API ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
--   Relicense the package as LGPL-3.0-or-later, with a more permissive exception for the templates ([#76](https://github.com/Boehringer-Ingelheim/dso/pull/76))
+- Refactor CLI into separate module ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
+- Defer imports in CLI until they are actually needed to speed up CLI ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
+- Make all modules explicitly private that are not part of the public API ([#30](https://github.com/Boehringer-Ingelheim/dso/pull/30))
+- Relicense the package as LGPL-3.0-or-later, with a more permissive exception for the templates ([#76](https://github.com/Boehringer-Ingelheim/dso/pull/76))
 
 ## v0.10.1
 
 ### Fixes
 
--   Take comments into account when linting for `DSO001` ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69))
--   Make it possible to override watermarks/disclaimers with a simple `null` ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69)).
--   Compile _all_ configs on `dso repro`, not just the ones relvant to the specified stage. This is required because we don't
+- Take comments into account when linting for `DSO001` ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69))
+- Make it possible to override watermarks/disclaimers with a simple `null` ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69)).
+- Compile _all_ configs on `dso repro`, not just the ones relvant to the specified stage. This is required because we don't
     know which other stages dvc might compile ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69)).
--   Make `get-config` compatible with dvc matrix stages ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69)).
+- Make `get-config` compatible with dvc matrix stages ([#69](https://github.com/Boehringer-Ingelheim/dso/pull/69)).
 
 ### Template updates
 
--   Do not ignore the `.gitignore` files in output/report directories of template ([#63](https://github.com/Boehringer-Ingelheim/dso/pull/63))
--   Update `.pre-commit-config.yaml` for pre-commit 4.x ([#63](https://github.com/Boehringer-Ingelheim/dso/pull/63))
+- Do not ignore the `.gitignore` files in output/report directories of template ([#63](https://github.com/Boehringer-Ingelheim/dso/pull/63))
+- Update `.pre-commit-config.yaml` for pre-commit 4.x ([#63](https://github.com/Boehringer-Ingelheim/dso/pull/63))
 
 ## v0.10.0
 
 ### Template updates
 
--   Improve instruction text in quarto template to get users started more quickly ([#40](https://github.com/Boehringer-Ingelheim/dso/pull/40))
--   Add `.gitignore` catch-all clauses for `output` and `report` folders in stages to not pick up data and repots being tracked via git ([#46](https://github.com/Boehringer-Ingelheim/dso/issues/46)).
--   Every dso project is now also a [uv project](https://docs.astral.sh/uv/concepts/projects/#building-projects) declaring Python dependencies in `pyproject.toml`. This makes it possible to
+- Improve instruction text in quarto template to get users started more quickly ([#40](https://github.com/Boehringer-Ingelheim/dso/pull/40))
+- Add `.gitignore` catch-all clauses for `output` and `report` folders in stages to not pick up data and repots being tracked via git ([#46](https://github.com/Boehringer-Ingelheim/dso/issues/46)).
+- Every dso project is now also a [uv project](https://docs.astral.sh/uv/concepts/projects/#building-projects) declaring Python dependencies in `pyproject.toml`. This makes it possible to
     use a different dso version per project and makes it easy to work with virtual Python environments ([#52](https://github.com/Boehringer-Ingelheim/dso/pull/52))
--   bash templates now include `-euo pipefail` settings, ensuring that stages fail early and return a nonzero error code if something failed ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
+- bash templates now include `-euo pipefail` settings, ensuring that stages fail early and return a nonzero error code if something failed ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
 
 ### Fixes
 
--   Remove vendored `hiyapyco` code since required changes were released upstream in v0.7.0 ([#45](https://github.com/Boehringer-Ingelheim/dso/pull/45)).
--   `None` values in `params.in.yaml` can now be used to override anything, e.g. to disable watermarking only in a specific stage ([#45](https://github.com/Boehringer-Ingelheim/dso/pull/45)).
--   Clean up existing `*.rmarkdown` files in quarto stage before running `quarto render`. This fixes issues with re-running quarto stages that failed in the previous attempt ([#57](https://github.com/Boehringer-Ingelheim/dso/pull/57)).
--   DSO now respects a `DSO_SKIP_CHECK_ASK_PRE_COMMIT` environment variable. If it is set
+- Remove vendored `hiyapyco` code since required changes were released upstream in v0.7.0 ([#45](https://github.com/Boehringer-Ingelheim/dso/pull/45)).
+- `None` values in `params.in.yaml` can now be used to override anything, e.g. to disable watermarking only in a specific stage ([#45](https://github.com/Boehringer-Ingelheim/dso/pull/45)).
+- Clean up existing `*.rmarkdown` files in quarto stage before running `quarto render`. This fixes issues with re-running quarto stages that failed in the previous attempt ([#57](https://github.com/Boehringer-Ingelheim/dso/pull/57)).
+- DSO now respects a `DSO_SKIP_CHECK_ASK_PRE_COMMIT` environment variable. If it is set
     to anything that evaluates as `True`, we skip the check if pre-commit is installed. This was a
     requirement introduced by the R API package, see [#50](https://github.com/Boehringer-Ingelheim/dso/issues/50) ([#58](https://github.com/Boehringer-Ingelheim/dso/pull/58)).
--   Improve logging for "missing path" warning during `compile-config` ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
--   Improve logging for missing parameters in `dvc.yaml` during `get-config` ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
--   Make sure internal calls to the dso pandocfilter use the same python and dso version as the parent command. This is important for the upcoming `dso-mgr` feature ([#61](https://github.com/Boehringer-Ingelheim/dso/pull/61)).
+- Improve logging for "missing path" warning during `compile-config` ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
+- Improve logging for missing parameters in `dvc.yaml` during `get-config` ([#59](https://github.com/Boehringer-Ingelheim/dso/pull/59)).
+- Make sure internal calls to the dso pandocfilter use the same python and dso version as the parent command. This is important for the upcoming `dso-mgr` feature ([#61](https://github.com/Boehringer-Ingelheim/dso/pull/61)).
 
 ## v0.9.0
 
 ### New Features
 
--   `dso watermark` now supports files in PDF format. With this change, quarto reports using the watermark feature can
+- `dso watermark` now supports files in PDF format. With this change, quarto reports using the watermark feature can
     be rendered to PDF, too ([#26](https://github.com/Boehringer-Ingelheim/dso/pull/26)).
 
 ### Fixes
 
--   Fix linting rule DSO001: It is now allowed to specify additional arguments in `read_params()`, e.g. `quiet = TRUE` ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36)).
--   It is now possible to use Jinja2 interpolation in combination with `!path` objects ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36))
--   Improve error messages when `dso get-config` can't find required input files ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36))
+- Fix linting rule DSO001: It is now allowed to specify additional arguments in `read_params()`, e.g. `quiet = TRUE` ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36)).
+- It is now possible to use Jinja2 interpolation in combination with `!path` objects ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36))
+- Improve error messages when `dso get-config` can't find required input files ([#36](https://github.com/Boehringer-Ingelheim/dso/pull/36))
 
 ### Documentation
 
--   Documentation is now built via sphinx and hosted on GitHub pages: https://boehringer-ingelheim.github.io/dso/ ([#35](https://github.com/Boehringer-Ingelheim/dso/pull/35)).
+- Documentation is now built via sphinx and hosted on GitHub pages: <https://boehringer-ingelheim.github.io/dso/> ([#35](https://github.com/Boehringer-Ingelheim/dso/pull/35)).
 
 ### Template updates
 
--   Make instruction comments in quarto template more descriptive ([#33](https://github.com/Boehringer-Ingelheim/dso/pull/33)).
--   Include `params.yaml` in default project `.gitignore`. We decided to not track `params.yaml` in git anymore
+- Make instruction comments in quarto template more descriptive ([#33](https://github.com/Boehringer-Ingelheim/dso/pull/33)).
+- Include `params.yaml` in default project `.gitignore`. We decided to not track `params.yaml` in git anymore
     since it adds noise during code review and led to merge conflicts in some cases. In the future, a certain
     `dso` version will be tied to each project, improving reproducibility also without `params.yaml` files.
 
 ### Migration advice
 
--   Add `params.yaml` to your project-level `.gitignore`. Then execute `find -iname "params.yaml" -exec git rm --cached {} \;`
+- Add `params.yaml` to your project-level `.gitignore`. Then execute `find -iname "params.yaml" -exec git rm --cached {} \;`
     to untrack existing `params.yaml` files.
 
 ## v0.8.2
 
 ### Fixes
 
--   Fixed params.yaml sorting issue - params.yaml order will be kept intact when using `dso get-config`
+- Fixed params.yaml sorting issue - params.yaml order will be kept intact when using `dso get-config`
 
 ## v0.8.1
 
 ### Fixes
 
--   Fixed and issue with spaces in image filenames when watermarking a quarto document
+- Fixed and issue with spaces in image filenames when watermarking a quarto document
 
 ## v0.8.0
 
 ### New Features
 
--   `dso init` and `dso create folder` now also work in existing directories. In such case missing files will be added
+- `dso init` and `dso create folder` now also work in existing directories. In such case missing files will be added
     from the template, but existing files are never overwritten.
--   There's now a template for a bash stage available in `dso create stage`. The stage template needs can be specified
+- There's now a template for a bash stage available in `dso create stage`. The stage template needs can be specified
     via the `--template` flag, otherwise the user is prompted to choose a template.
--   `dso` now has flags to control logging verbosity. The default log-level is `info`. `-q` will set it to `warning`,
+- `dso` now has flags to control logging verbosity. The default log-level is `info`. `-q` will set it to `warning`,
     `-qq` to `error` and `-v` to `debug`. The "quiet" option can also be activated by setting the environment variable
     `DSO_QUIET=1` or `DSO_QUIET=2`.
--   `dso exec` and `dso get-config` now have a `--skip-compile` flag to disable automatic internal calls to
+- `dso exec` and `dso get-config` now have a `--skip-compile` flag to disable automatic internal calls to
     `dso compile-config`. The flag can also be activated by setting the environment variable `DSO_SKIP_COMPILE=1`.
 
 ### Fixes
 
--   Fix that compile-config also compiles parents when in a directory without a `params.in.yaml` file.
--   The order of dictionaries is now preserved by `dso get-config`.
--   When running `dso init` or `dso create`, `dso compile-config` is now only executed
+- Fix that compile-config also compiles parents when in a directory without a `params.in.yaml` file.
+- The order of dictionaries is now preserved by `dso get-config`.
+- When running `dso init` or `dso create`, `dso compile-config` is now only executed
     after it was clearly communicated with the user that the project/stage/folder was successfully created.
--   Specifying a stylesheet using `css` via `dso.quarto` is now possible.
--   Adjusted the log level of some messages to more reasonable defaults. Some messages that were previously `info`
+- Specifying a stylesheet using `css` via `dso.quarto` is now possible.
+- Adjusted the log level of some messages to more reasonable defaults. Some messages that were previously `info`
     messages are now `debug` messages and not shown by default.
--   When running `dso repro`, configuration is only compiled once and not recompiled when `dso exec` or `dso get-config`
+- When running `dso repro`, configuration is only compiled once and not recompiled when `dso exec` or `dso get-config`
     is called internally. This reduces runtime and redundant log messages.
 
 ## v0.7.0
 
--   Improved watermarking support
+- Improved watermarking support
 
-    -   Added test cases for watermarking and the pandocfilter
-    -   Support for SVG images
-    -   There's now a `dso watermark` command line interface to watermark specified image files. In the future this
+  - Added test cases for watermarking and the pandocfilter
+  - Support for SVG images
+  - There's now a `dso watermark` command line interface to watermark specified image files. In the future this
         can be used to provide a custom plotting device in R that performs the watermarking.
-    -   Changed the watermark layout to use a tiled pattern which is less obstrusive and is guaranteed to cover the entire plot
-    -   The watermark is now fully configurable via `params.in.yaml`:
+  - Changed the watermark layout to use a tiled pattern which is less obstrusive and is guaranteed to cover the entire plot
+  - The watermark is now fully configurable via `params.in.yaml`:
 
         ```yaml
         dso:
@@ -270,37 +300,38 @@ dso init will re-add all files from the project template that are missing from y
                     font_outline_color: "#AA111160"
         ```
 
--   Fix issue where dso was stuck in an infinity loop while searching for a config file. Now it should fail
+- Fix issue where dso was stuck in an infinity loop while searching for a config file. Now it should fail
     if it can't be found. To realize this the funcitonality for searching parent folders for a certain file
     that was used in different places was refactored into a separate function.
 
 ## v0.6.1
 
--   Fix issue in `dso get-config` if multiple parameters have been used in a single line in `deps:`.
+- Fix issue in `dso get-config` if multiple parameters have been used in a single line in `deps:`.
 
 ## v0.6.0
 
--   Add a `dso lint` command that performs consistency checks on dso projects. For now, only a single rule is
+- Add a `dso lint` command that performs consistency checks on dso projects. For now, only a single rule is
     implemented, but it can be easily extended. The rule:
-    -   `DSO001`: In a quarto stage, ensure `dso::read_params` is called and stage name is correct.
--   Logging information is now printed to STDERR instead of STDOUT
--   Add `dso get-config <STAGE>` which will compile and print the configuration for a given stage to STDOUT.
+  - `DSO001`: In a quarto stage, ensure `dso::read_params` is called and stage name is correct.
+- Logging information is now printed to STDERR instead of STDOUT
+- Add `dso get-config <STAGE>` which will compile and print the configuration for a given stage to STDOUT.
     Additionally, it filters the output to fields that are specified in `dvc.yaml` which forces the user
     to declare all dependencies in `dvc.yaml`.
--   Add automated watermarking of plots in quarto documents as experimental feature. For now, only png images are supported.
+- Add automated watermarking of plots in quarto documents as experimental feature. For now, only png images are supported.
     To enable, add to `params.in.yaml`:
 
-    -   `dso.quarto.watermark`: a text to be shown as watermark.
-    -   `dso.quarto.disclaimer.text`: a text to be shown as disclaimer box.
-    -   `dso.quarto.disclaimer.title`: title of the disclaimer box.
+  - `dso.quarto.watermark`: a text to be shown as watermark.
+  - `dso.quarto.disclaimer.text`: a text to be shown as disclaimer box.
+  - `dso.quarto.disclaimer.title`: title of the disclaimer box.
 
     The disclaimer box is only shown if both text and title are set.
 
 ### Migration advice
 
--   Update `dso-r` to v0.3.0 to take advantage of `dso get-config`.
+- Update `dso-r` to v0.3.0 to take advantage of `dso get-config`.
 
--   Add the following rule to your `.pre-commit-config.yaml`:
+- Add the following rule to your `.pre-commit-config.yaml`:
+
     ```yaml
       - repo: local
           hooks:
@@ -314,71 +345,71 @@ dso init will re-add all files from the project template that are missing from y
 
 ## v0.5.0
 
--   `dso.before_script` is now `dso.quarto.before_script`. This change has been made because different "exec" modules
+- `dso.before_script` is now `dso.quarto.before_script`. This change has been made because different "exec" modules
     will likely need different setup-scripts (i.e. environment modules). If the script shall be shared nevertheless,
     this can be done with jinja templating.
--   It is now possible to specify bibliography files in `params.in.config:dso.quarto.bibliography` using `!path`.
--   Upon `dso repro`, the CLI asks once if the user wants to install the pre-commit hooks
+- It is now possible to specify bibliography files in `params.in.config:dso.quarto.bibliography` using `!path`.
+- Upon `dso repro`, the CLI asks once if the user wants to install the pre-commit hooks
 
 ### Migration advice
 
--   Move `dso.before_script` to `dso.quarto.before_script` in all your config files.
--   Update all quarto stages to depend only on `params:dso.quarto` instead of `params:dso`. This will avoid
+- Move `dso.before_script` to `dso.quarto.before_script` in all your config files.
+- Update all quarto stages to depend only on `params:dso.quarto` instead of `params:dso`. This will avoid
     invalidating the cache unnecessarily.
--   add `/.dso.json` to your .gitignore file
+- add `/.dso.json` to your .gitignore file
 
 ## v0.4.4
 
--   Remove confirmation before overwriting a newer `params.yaml` file - It turned out not to work well with
+- Remove confirmation before overwriting a newer `params.yaml` file - It turned out not to work well with
     switching branches in git and led to way too many unnecessary questions.
--   Do not fail when `dso.quarto` is `null` in `params.in.yaml` (not all cases were addressed in v0.4.3)
+- Do not fail when `dso.quarto` is `null` in `params.in.yaml` (not all cases were addressed in v0.4.3)
 
 ## v0.4.3
 
--   Fix confirmation to overwrite params.yaml
--   Improve error message when `dso exec quarto` fails
--   Make pre-commit hooks verbose
--   Do not fail when `dso.quarto` is `null` in `params.in.yaml`
+- Fix confirmation to overwrite params.yaml
+- Improve error message when `dso exec quarto` fails
+- Make pre-commit hooks verbose
+- Do not fail when `dso.quarto` is `null` in `params.in.yaml`
 
 ## v0.4.2
 
--   Update quarto template to include `dso` params as dependency
--   Reduce the number of false-positives when asking for confirmation to overwrite params.yaml
+- Update quarto template to include `dso` params as dependency
+- Reduce the number of false-positives when asking for confirmation to overwrite params.yaml
 
 ## v0.4.1
 
--   Allow a tolerance of 1s when comparing timestamps of params.in.yaml and params.yaml
+- Allow a tolerance of 1s when comparing timestamps of params.in.yaml and params.yaml
 
 ## v0.4.0
 
--   Ask for confirmation before overwriting a newer `params.yaml` file
--   The log messages when compiling configuration files have improved
--   Added `dso exec quarto`, a convenient wrapper to execute quarto stages
-    -   Quarto configuration/headers will be read from `params.yaml:qso.quarto`
-    -   A shell snippet specified in `params.yaml:dso.before_script` will be executed before rendering the report.
+- Ask for confirmation before overwriting a newer `params.yaml` file
+- The log messages when compiling configuration files have improved
+- Added `dso exec quarto`, a convenient wrapper to execute quarto stages
+  - Quarto configuration/headers will be read from `params.yaml:qso.quarto`
+  - A shell snippet specified in `params.yaml:dso.before_script` will be executed before rendering the report.
         This is useful for setting up the environment, e.g. by loading modules
 
 ## v0.3.1
 
--   Update quarto template to be concordant with latest dso-r version
+- Update quarto template to be concordant with latest dso-r version
 
 ## v0.3.0
 
--   Updated quarto template to use dso code to load files
--   `dso compile-config` now optionally supports specifying a list of paths
--   Renamed `dso create project` to `dso init`
--   Added `dso create folder` in addition to `dso create stage`.
--   Currently only one template for `dso init`, `dso create folder` and `dso create stage` but prepared the project
+- Updated quarto template to use dso code to load files
+- `dso compile-config` now optionally supports specifying a list of paths
+- Renamed `dso create project` to `dso init`
+- Added `dso create folder` in addition to `dso create stage`.
+- Currently only one template for `dso init`, `dso create folder` and `dso create stage` but prepared the project
     to easily support multiple templates in the future
--   Improved pre-commit config. Install it using `pre-commit install` in the project. It automatically performs some
+- Improved pre-commit config. Install it using `pre-commit install` in the project. It automatically performs some
     consistency checks and dvc pull/push/checkout.
 
 ## v0.2.0
 
--   It's now possible to specify paths via the `!path` tag in params.in.yaml. These paths will be checked for existence
+- It's now possible to specify paths via the `!path` tag in params.in.yaml. These paths will be checked for existence
     and automatically resolved such that they are always relative to the compiled params.yaml files.
 
 ## v0.1.0
 
--   initial prototype
--   `dso create` command
+- initial prototype
+- `dso create` command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ maintainers = [
 authors = [
   { name = "Gregor Sturm" },
   { name = "Thomas Schwarzl" },
+  { name = "Daniel Schreyer" },
   { name = "Alexander Peltzer" },
 ]
 requires-python = ">=3.11"

--- a/src/dso/_compile_config.py
+++ b/src/dso/_compile_config.py
@@ -34,7 +34,7 @@ PARAMS_YAML_DISCLAIMER = dedent(
 
 
 def _normalize_windows_separators(obj):
-    """
+    r"""
     Recursively replace forward slashes with backslashes in strings on Windows.
 
     Heuristics:
@@ -53,10 +53,11 @@ def _normalize_windows_separators(obj):
 
 
 def _format_path_for_yaml(path: Path, *, base: Path, relative: bool) -> str:
-    """
+    r"""
     Return a string to be written into YAML using OS-native separators:
-      - relative=True  -> relative path with OS-native separators
-      - relative=False -> absolute native path (Windows => '\\', POSIX => '/')
+
+    - relative=True  -> relative path with OS-native separators
+    - relative=False -> absolute native path (Windows => '\\', POSIX => '/')
     """
     path = Path(path).resolve()
     base = Path(base).resolve()
@@ -132,9 +133,7 @@ def _load_yaml_with_auto_adjusting_paths(
             return _format_path_for_yaml(target, base=destination, relative=relative)
 
         def get_adjusted(self) -> str:
-            """
-            Return the adjusted path as a string with OS-native separators.
-            """
+            """Return the adjusted path as a string with OS-native separators."""
             adj = (source / self.path).resolve()
             return str(adj) if not relative else os.path.relpath(adj, start=destination.resolve())
 

--- a/src/dso/_get_config.py
+++ b/src/dso/_get_config.py
@@ -1,5 +1,7 @@
 """Get configuration for a stage based on params.in.yaml and dvc.yaml"""
 
+from __future__ import annotations
+
 import re
 import sys
 from collections.abc import Collection
@@ -30,40 +32,80 @@ def _filter_nested_dict(data: dict, keys: Collection[str]) -> dict:
 
 
 def get_config(stage: str, *, all: bool = False, skip_compile: bool = False) -> dict:
-    """
-    Get the configuration for a given stage
+    r"""
+    Get the configuration for a given stage.
 
-    By default, the configuration is filtered to include only the keys that are mentioned in `dvc.yaml` to force
-    declaring all dependencies.
+    Resolution rules for the `stage` argument:
+      - If it contains a stage name (e.g. `path/to/dir:stage_name`), split on the
+        *stage* separator colon **without** confusing Windows drive letters like `C:\`.
+      - If the path part is ABSOLUTE, use it as-is.
+      - If the path part is RELATIVE, resolve **first** against the current working
+        directory, and if not found, resolve against the project root (where `.git` lives).
+
+    By default, the configuration is filtered to include only keys mentioned in the
+    corresponding stage in `dvc.yaml`. Use `all=True` to return the full config.
 
     Parameters
     ----------
-    stage
-        path to the stage relative to the project root. If multiple stages are defined in the `dvc.yaml` file,
-        this should include the stage separated by a colon, e.g. `path/to/stage:stage_name`.
-    all
+    stage : str
+        Path to the stage directory (absolute or relative), optionally followed by
+        `:stage_name` if multiple stages exist in the directory's `dvc.yaml`.
+    all : bool
         If true, the config is not filtered based on the `dvc.yaml` file.
-    skip_compile
-        If `True`, do not compile the config before loading it.
-        If `False`, always compile.
+    skip_compile : bool
+        If `True`, do not compile the config before loading it. If `False`, always compile.
     """
     from dso._compile_config import compile_all_configs
 
     proj_root = get_project_root(Path.cwd())
-    log.info(f"Retrieving config for stage ./{stage}")
-    if ":" in stage:
-        stage_path, stage_name = stage.split(":")
-    else:
-        stage_path, stage_name = stage, None
 
-    stage_path = proj_root / stage_path
-    if not stage_path.exists():
+    # --- robustly split "path[:stage_name]" without breaking on Windows drive letters ---
+    def split_stage_arg(arg: str) -> tuple[str, str | None]:
+        # If it starts with a Windows drive like 'C:\' or 'D:/', ignore that first colon
+        if re.match(r"^[A-Za-z]:[\\/]", arg):
+            idx = arg.find(":", 2)  # search ':' after 'C:' prefix
+            if idx != -1:
+                return arg[:idx], arg[idx + 1 :]
+            return arg, None
+        # Non-windows-absolute (or relative): split on the last ':' to be safe
+        if ":" in arg:
+            left, right = arg.rsplit(":", 1)
+            return left, right
+        return arg, None
+
+    stage_part, stage_name = split_stage_arg(stage)
+
+    # Build a concrete directory path for the stage with CWD-first resolution for relative paths
+    stage_path_candidate = Path(stage_part)
+
+    if stage_path_candidate.is_absolute():
+        stage_path = stage_path_candidate
+    else:
+        # 1) Try relative to CWD
+        cwd_candidate = (Path.cwd() / stage_path_candidate).resolve()
+        if cwd_candidate.is_dir():
+            stage_path = cwd_candidate
+        else:
+            # 2) Fall back to relative to project root
+            stage_path = (proj_root / stage_path_candidate).resolve()
+
+    # Friendly logging: show relative-to-project if possible
+    try:
+        disp = f"./{stage_path.relative_to(proj_root)}"
+    except ValueError:
+        disp = str(stage_path)
+    log.info(f"Retrieving config for stage {disp}")
+
+    if not stage_path.exists() or not stage_path.is_dir():
         log.error(f"Path to stage does not exist: {stage_path}")
         sys.exit(1)
 
     if not skip_compile:
-        log.debug("Skipping compilation of configuration")
+        log.debug("Compiling configuration")
         compile_all_configs([stage_path])
+    else:
+        log.debug("Skipping compilation of configuration")
+
     yaml = YAML(typ="safe")
 
     try:
@@ -74,51 +116,56 @@ def get_config(stage: str, *, all: bool = False, skip_compile: bool = False) -> 
 
     if all:
         return config
-    else:
-        try:
-            dvc_config = yaml.load(stage_path / "dvc.yaml")
-        except OSError:
-            log.error("No dvc.yaml found in directory.")
-            sys.exit(1)
 
-        try:
-            dvc_stages = dvc_config.get("stages", None)
-        except AttributeError:
-            dvc_stages = None
+    # Read dvc.yaml to determine which parameters to keep
+    try:
+        dvc_config = yaml.load(stage_path / "dvc.yaml")
+    except OSError:
+        log.error("No dvc.yaml found in directory.")
+        sys.exit(1)
 
-        if not dvc_stages:
-            log.error("At least one stage must be defined in `dvc.yaml` (unless --all is specified)")
-            sys.exit(1)
-        elif len(dvc_stages) > 1 and stage_name is None:
-            log.error(
-                "If multiple stages are defined in `dvc.yaml`, the stage name must be given using `path/to/stage:stage_name`"
-            )
-            sys.exit(1)
-        elif len(dvc_stages) == 1:
-            dvc_stage_config = next(iter(dvc_stages.values()))
-        else:
-            dvc_stage_config = dvc_stages[stage_name]
+    try:
+        dvc_stages = dvc_config.get("stages", None)
+    except AttributeError:
+        dvc_stages = None
 
-        # We want to include parameters mentioned in either `params`, `deps`, `outs`.
-        # The parameters in `deps`/`outs` are encapsulated in `${ <param> }`
-        is_matrix_stage = "matrix" in dvc_stage_config
-        if (params := dvc_stage_config.get("params", [])) is None:
-            keep_params = set()
-        else:
-            keep_params = set(params)
-        dvc_param_pat = re.compile(r"\$\{\s*(.*?)\s*\}")
-        for dep in dvc_stage_config.get("deps", []):
-            if match := dvc_param_pat.findall(dep):
-                keep_params.update(match)
-        for out in dvc_stage_config.get("outs", []):
-            if match := dvc_param_pat.findall(out):
-                keep_params.update(match)
-
-        log.info(
-            f"Only including the following parameters which are listed in `dvc.yaml`: [green]{', '.join(keep_params)}"
+    if not dvc_stages:
+        log.error("At least one stage must be defined in `dvc.yaml` (unless --all is specified)")
+        sys.exit(1)
+    elif len(dvc_stages) > 1 and stage_name is None:
+        log.error(
+            "If multiple stages are defined in `dvc.yaml`, the stage name must be given using `path/to/stage:stage_name`"
         )
+        sys.exit(1)
+    elif len(dvc_stages) == 1:
+        dvc_stage_config = next(iter(dvc_stages.values()))
+    else:
+        dvc_stage_config = dvc_stages.get(stage_name)
+        if dvc_stage_config is None:
+            log.error(f"Stage '{stage_name}' not found in dvc.yaml.")
+            sys.exit(1)
 
-        if is_matrix_stage:
-            keep_params = {p for p in keep_params if not (p.startswith("item.") or p == "item")}
+    # We want to include parameters mentioned in either `params`, `deps`, `outs`.
+    # The parameters in `deps`/`outs` are encapsulated in `${ <param> }`
+    is_matrix_stage = "matrix" in dvc_stage_config
+    if (params := dvc_stage_config.get("params", [])) is None:
+        keep_params = set()
+    else:
+        keep_params = set(params)
 
-        return _filter_nested_dict(config, keep_params)
+    dvc_param_pat = re.compile(r"\$\{\s*(.*?)\s*\}")
+    for dep in dvc_stage_config.get("deps", []) or []:
+        if match := dvc_param_pat.findall(dep):
+            keep_params.update(match)
+    for out in dvc_stage_config.get("outs", []) or []:
+        if match := dvc_param_pat.findall(out):
+            keep_params.update(match)
+
+    log.info(
+        f"Only including the following parameters which are listed in `dvc.yaml`: [green]{', '.join(sorted(keep_params))}"
+    )
+
+    if is_matrix_stage:
+        keep_params = {p for p in keep_params if not (p.startswith("item.") or p == "item")}
+
+    return _filter_nested_dict(config, keep_params)

--- a/src/dso/_quarto.py
+++ b/src/dso/_quarto.py
@@ -1,12 +1,12 @@
 """Helper functions for rendering quarto documents"""
 
+import contextlib
 import os
-import stat
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
-import contextlib
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent, indent
@@ -32,7 +32,7 @@ def _make_pandoc_filter_script() -> Path:
         fd, script_path = tempfile.mkstemp(suffix=".sh")
         os.close(fd)
         p = Path(script_path)
-        p.write_text(f"#!/bin/bash\n{sys.executable} -m dso.pandocfilter \"$@\"\n", encoding="utf-8")
+        p.write_text(f'#!/bin/bash\n{sys.executable} -m dso.pandocfilter "$@"\n', encoding="utf-8")
         p.chmod(p.stat().st_mode | stat.S_IEXEC)
         return p
 
@@ -88,8 +88,7 @@ def render_quarto(
             quarto = shutil.which("quarto")
             if not quarto:
                 raise FileNotFoundError(
-                    "Quarto CLI not found on PATH (required on Windows). "
-                    "Install Quarto or add it to PATH."
+                    "Quarto CLI not found on PATH (required on Windows). Install Quarto or add it to PATH."
                 )
 
             cmd = [quarto, "render", str(quarto_dir), "--execute", "--output-dir", str(report_dir)]

--- a/src/dso/_quarto.py
+++ b/src/dso/_quarto.py
@@ -17,6 +17,7 @@ from ruamel.yaml import YAML
 def _make_pandoc_filter_script() -> Path:
     """
     Create a temporary wrapper script that calls: python -m dso.pandocfilter
+
     Returns the script Path. Caller must delete it.
     """
     if os.name == "nt":

--- a/src/dso/_quarto.py
+++ b/src/dso/_quarto.py
@@ -2,14 +2,39 @@
 
 import os
 import stat
+import shutil
 import subprocess
 import sys
 import tempfile
+import contextlib
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent, indent
 
 from ruamel.yaml import YAML
+
+
+def _make_pandoc_filter_script() -> Path:
+    """
+    Create a temporary wrapper script that calls: python -m dso.pandocfilter
+    Returns the script Path. Caller must delete it.
+    """
+    if os.name == "nt":
+        # Windows: use a .cmd so pandoc can execute it
+        fd, script_path = tempfile.mkstemp(suffix=".cmd")
+        os.close(fd)
+        p = Path(script_path)
+        # Quote python path; forward all args
+        p.write_text(f'@echo off\r\n"{sys.executable}" -m dso.pandocfilter %*\r\n', encoding="utf-8")
+        return p
+    else:
+        # POSIX: use a .sh and make it executable
+        fd, script_path = tempfile.mkstemp(suffix=".sh")
+        os.close(fd)
+        p = Path(script_path)
+        p.write_text(f"#!/bin/bash\n{sys.executable} -m dso.pandocfilter \"$@\"\n", encoding="utf-8")
+        p.chmod(p.stat().st_mode | stat.S_IEXEC)
+        return p
 
 
 def render_quarto(
@@ -29,63 +54,77 @@ def render_quarto(
     report_dir
         Output directory of the rendered document
     before_script
-        Bash snippet to execute before running quarto (e.g. to setup the enviornment)
+        Bash snippet to execute before running quarto (e.g. to setup the environment)
+        (Ignored on Windows)
     """
-    before_script = indent(before_script, " " * 8)
-    report_dir = report_dir.absolute()
-    report_dir.mkdir(exist_ok=True)
+    quarto_dir = Path(quarto_dir)
+    report_dir = Path(report_dir).absolute()
+    cwd = Path(cwd)
 
-    # clean up existing `.rmarkdown` files that may interfere with rendering
-    # these are leftovers from a previous, failed `quarto render` attempt. If they still exist, the next attempt
-    # fails. We remove them *before* the run instead of cleaning them up *after* the run, because they
-    # may be useful for debugging failures.
-    # see https://github.com/Boehringer-Ingelheim/dso/issues/54
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clean up leftover .rmarkdown files from previous failed render attempts
     for f in quarto_dir.glob("*.rmarkdown"):
         if f.is_file():
-            f.unlink()
+            with contextlib.suppress(OSError):
+                f.unlink()
 
-    # Enable pandocfilter if requested.
-    # We create a temporary script that then calls the current python binary with the dso.pandocfilter module
-    # This may seem cumbersome, but we do it this way because
-    #  * pandoc only supports a single binary for `--filter`, referring to subcommands or `-m` is not possible here
-    #  * we want to ensure that exactly the same python/dso version is used for the pandocfilter as for the
-    #    parent command (important when running through dso-mgr)
-    filter_script = None
+    # Optional pandoc filter wrapper
+    filter_script: Path | None = None
     if with_pandocfilter:
-        with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
-            f.write("#!/bin/bash\n")
-            f.write(f'{sys.executable} -m dso.pandocfilter "$@"\n')
-            filter_script = Path(f.name)
+        filter_script = _make_pandoc_filter_script()
 
-        filter_script.chmod(filter_script.stat().st_mode | stat.S_IEXEC)
+    # Quiet flag from env (compatible with previous behavior)
+    quiet_env = os.environ.get("DSO_QUIET", "0")
+    quiet = bool(int(quiet_env)) if quiet_env.isdigit() else False
 
-        pandocfilter = f"--filter {filter_script}"
-    else:
-        pandocfilter = ""
+    # Bump Deno memory for Quarto
+    env = os.environ.copy()
+    env.setdefault("QUARTO_DENO_V8_OPTIONS", "--max-old-space-size=8192")
 
-    # propagate quiet setting to quarto
-    quiet = "--quiet" if bool(int(os.environ.get("DSO_QUIET", 0))) else ""
-    script = dedent(
-        f"""\
-        #!/bin/bash
-        set -euo pipefail
+    try:
+        if os.name == "nt":
+            # Windows: call Quarto CLI directly (no /bin/bash)
+            quarto = shutil.which("quarto")
+            if not quarto:
+                raise FileNotFoundError(
+                    "Quarto CLI not found on PATH (required on Windows). "
+                    "Install Quarto or add it to PATH."
+                )
 
-        # this flags enables building larger reports with embedded resources
-        export QUARTO_DENO_V8_OPTIONS=--max-old-space-size=8192
+            cmd = [quarto, "render", str(quarto_dir), "--execute", "--output-dir", str(report_dir)]
+            if quiet:
+                cmd.append("--quiet")
+            if filter_script is not None:
+                cmd += ["--filter", str(filter_script)]
 
-        {before_script}
+            subprocess.run(cmd, cwd=str(cwd), env=env, check=True)
 
-        quarto render "{quarto_dir}" --execute --output-dir "{report_dir}" {quiet} {pandocfilter}
-        """
-    )
-    res = subprocess.run(script, shell=True, executable="/bin/bash", cwd=cwd)
+        else:
+            # POSIX: honor the bash snippet and use /bin/bash
+            before_script_indented = indent(before_script or "", " " * 8)
+            filter_arg = f"--filter {filter_script}" if filter_script else ""
+            quiet_arg = "--quiet" if quiet else ""
 
-    # clean up
-    if filter_script is not None:
-        filter_script.unlink()
+            script = dedent(
+                f"""\
+                #!/bin/bash
+                set -euo pipefail
 
-    if res.returncode:
-        sys.exit(res.returncode)
+                # this flag enables building larger reports with embedded resources
+                export QUARTO_DENO_V8_OPTIONS="${{QUARTO_DENO_V8_OPTIONS:---max-old-space-size=8192}}"
+
+                {before_script_indented}
+
+                quarto render "{quarto_dir}" --execute --output-dir "{report_dir}" {quiet_arg} {filter_arg}
+                """
+            )
+            subprocess.run(script, shell=True, executable="/bin/bash", cwd=str(cwd), env=env, check=True)
+
+    finally:
+        if filter_script is not None:
+            with contextlib.suppress(OSError):
+                filter_script.unlink()
 
 
 @contextmanager
@@ -93,10 +132,12 @@ def quarto_config_yml(quarto_config: dict | None, quarto_dir: Path):
     """Context manager that temporarily creates a _quarto.yml file and cleans up after itself"""
     if quarto_config is None:
         quarto_config = {}
-    config_file = quarto_dir / "_quarto.yml"
+    config_file = Path(quarto_dir) / "_quarto.yml"
     yaml = YAML(typ="safe")
-    yaml.dump(quarto_config, config_file)
+    with config_file.open("w", encoding="utf-8", newline="\n") as fh:
+        yaml.dump(quarto_config, fh)
     try:
         yield
     finally:
-        config_file.unlink()
+        with contextlib.suppress(FileNotFoundError, PermissionError):
+            config_file.unlink()

--- a/src/dso/_templates.py
+++ b/src/dso/_templates.py
@@ -44,8 +44,9 @@ _BINARY_EXTS = {
 
 
 def _split_template_libraries_env(raw: str) -> list[str]:
-    """
+    r"""
     Split DSO_TEMPLATE_LIBRARIES into paths/modules.
+
     - If os.pathsep is present, split on that.
     - Otherwise split on ':' but keep Windows drive specifiers like 'C:\'.
     """

--- a/src/dso/_watermark.py
+++ b/src/dso/_watermark.py
@@ -1,5 +1,7 @@
 """Add text-watermarks to images"""
 
+import os
+import contextlib
 import tempfile
 from abc import abstractmethod
 from importlib import resources
@@ -61,19 +63,19 @@ class Watermarker:
         for x in range(0, size[0], self.tile_size[0]):
             for y in range(0, size[1], self.tile_size[1]):
                 watermark_tiled.paste(watermark, (x, y))
-
         return watermark_tiled
 
     def _get_watermark_tile(self) -> Image.Image:
         """Get a tile of predefined size that contains the watermark text twice
-
         (once top left corner, once middle right - this leads to a regular pattern)
         """
         img = Image.new("RGBA", self.tile_size, color=(255, 255, 255, 0))
 
         d = ImageDraw.Draw(img)
-        with resources.open_binary(assets, "open_sans.ttf") as watermark_font:
-            font = ImageFont.truetype(watermark_font, self.font_size)
+
+        # Modern importlib.resources API (avoids deprecation warnings)
+        font_path = resources.files(assets) / "open_sans.ttf"
+        font = ImageFont.truetype(str(font_path), self.font_size)
 
         # Add text in top left corner
         d.text(
@@ -101,9 +103,9 @@ class Watermarker:
 
     @staticmethod
     def add_watermark(input_image: Path | str, output_image: Path | str, **kwargs):
-        """Add watermark to an image, using the different implementations base on the file type"""
+        """Add watermark to an image, using the different implementations based on the file type"""
         input_image = Path(input_image)
-        ext = input_image.suffix
+        ext = input_image.suffix.lower()
         if ext == ".svg":
             wm = SVGWatermarker(**kwargs)
         elif ext == ".pdf":
@@ -133,7 +135,7 @@ class PILWatermarker(Watermarker):
 class SVGWatermarker(Watermarker):
     """Add watermarks to SVG images. The watermark overlay will be a pixel graphic embedded in the svg."""
 
-    def _get_size(self, svg_image: compose.SVG):
+    def _get_size(self, svg_image: compose.SVG) -> tuple[int, int]:
         try:
             if svg_image.width is None or svg_image.height is None:
                 raise ValueError("Watermarking works only with SVG images that define an explicit width and height")
@@ -149,30 +151,54 @@ class SVGWatermarker(Watermarker):
         size = self._get_size(base_image)
 
         watermark_overlay = self.get_watermark_overlay(size)
-        with tempfile.NamedTemporaryFile(suffix=".png") as tf:
-            watermark_overlay.save(tf)
-            watermark_overlay_svg = compose.Image(*size, tf.name)
-        fig = compose.Figure(*size, base_image, watermark_overlay_svg)
-        fig.save(output_image)
+
+        # Windows-safe temp file usage: close FD before passing path to other libs
+        fd, tmp_png = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            watermark_overlay.save(tmp_png)
+            watermark_overlay_svg = compose.Image(*size, tmp_png)
+            fig = compose.Figure(*size, base_image, watermark_overlay_svg)
+            fig.save(output_image)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_png)
 
 
 class PDFWatermarker(Watermarker):
-    """Add watermarks to PDF images. The watermark overlay will be a pixel graphic embedded in the svg."""
+    """Add watermarks to PDF files. The watermark overlay will be a pixel graphic embedded per page."""
 
     # Inspired by https://www.geeksforgeeks.org/working-with-pdf-files-in-python/
     def apply_and_save(self, input_image: Path | str, output_image: Path | str):
-        """Apply the watermark to an image and save it to the specified output file"""
+        """Apply the watermark to each page and save to the specified output PDF"""
         reader = PdfReader(input_image)
         writer = PdfWriter()
-        for page_obj in reader.pages:
-            size = (int(page_obj.mediabox.width), int(page_obj.mediabox.height))
-            watermark_overlay = self.get_watermark_overlay(size)
-            with tempfile.NamedTemporaryFile(suffix=".pdf") as tf:
-                watermark_overlay.save(tf)
-                watermark_overlay_pdf = PdfReader(tf.file).pages[0]
-                page_obj.merge_page(watermark_overlay_pdf)
-                writer.add_page(page_obj)
+        try:
+            for page_obj in reader.pages:
+                size = (int(page_obj.mediabox.width), int(page_obj.mediabox.height))
+                watermark_overlay = self.get_watermark_overlay(size)
+
+                # Create a temp single-page PDF for the overlay; close FD immediately for Windows
+                fd, tmp_pdf = tempfile.mkstemp(suffix=".pdf")
+                os.close(fd)
+                try:
+                    # Pillow can save an RGBA as PDF; convert to RGB to be safe
+                    wm_for_pdf = watermark_overlay.convert("RGB")
+                    wm_for_pdf.save(tmp_pdf)  # produces a 1-page PDF
+
+                    overlay_reader = PdfReader(tmp_pdf)
+                    overlay_page = overlay_reader.pages[0]
+                    page_obj.merge_page(overlay_page)
+                    writer.add_page(page_obj)
+                finally:
+                    with contextlib.suppress(OSError):
+                        os.remove(tmp_pdf)
+        finally:
+            # Explicitly close the reader (good hygiene)
+            try:
+                reader.close()
+            except Exception:
+                pass
 
         with open(output_image, "wb") as f:
             writer.write(f)
-        reader.close()

--- a/src/dso/_watermark.py
+++ b/src/dso/_watermark.py
@@ -66,9 +66,7 @@ class Watermarker:
         return watermark_tiled
 
     def _get_watermark_tile(self) -> Image.Image:
-        """Get a tile of predefined size that contains the watermark text twice
-        (once top left corner, once middle right - this leads to a regular pattern)
-        """
+        """Get a tile of predefined size that contains the watermark text twice (once top left corner, once middle right - this leads to a regular pattern)"""
         img = Image.new("RGBA", self.tile_size, color=(255, 255, 255, 0))
 
         d = ImageDraw.Draw(img)
@@ -194,11 +192,7 @@ class PDFWatermarker(Watermarker):
                     with contextlib.suppress(OSError):
                         os.remove(tmp_pdf)
         finally:
-            # Explicitly close the reader (good hygiene)
-            try:
-                reader.close()
-            except Exception:
-                pass
+            reader.close()
 
         with open(output_image, "wb") as f:
             writer.write(f)

--- a/src/dso/_watermark.py
+++ b/src/dso/_watermark.py
@@ -1,7 +1,7 @@
 """Add text-watermarks to images"""
 
-import os
 import contextlib
+import os
 import tempfile
 from abc import abstractmethod
 from importlib import resources

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -47,7 +47,7 @@ def test_exec_quarto_bibliography(quarto_stage_bibliography):
     result = runner.invoke(dso_exec, ["quarto", stage_path])
     assert result.exit_code == 0
     assert (quarto_stage_bibliography / "report" / "quarto_stage.html").is_file()
-    assert "Knuth" in (quarto_stage_bibliography / "report" / "quarto_stage.html").read_text()
+    assert "Knuth" in (quarto_stage_bibliography / "report" / "quarto_stage.html").read_text(encoding="utf-8")
 
 
 def test_exec_quarto_stylesheet(quarto_stage_css):

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -1,3 +1,4 @@
+import os
 from os import chdir
 from textwrap import dedent
 
@@ -73,19 +74,24 @@ def test_get_config(dso_project):
         )
     )
 
+    # Normalize expected paths to OS-native separators
+    foo = os.path.normpath("input/A.txt")
+    bar = os.path.normpath("input/B.txt")
+    baz = os.path.normpath("input/C.txt")
+
     # raises an error because there are multiple stages
     with pytest.raises(SystemExit):
         get_config("mystage")
 
     assert get_config("mystage", all=True) == {
-        "parent": {"foo": "input/A.txt", "bar": "input/B.txt", "baz": "input/C.txt"},
+        "parent": {"foo": foo, "bar": bar, "baz": baz},
         "param": 42,
         "other": "rocket",
     }
 
-    assert get_config("mystage:mystage01") == {"parent": {"foo": "input/A.txt", "bar": "input/B.txt"}, "param": 42}
-    assert get_config("mystage:mystage02") == {"parent": {"foo": "input/A.txt"}, "param": 42}
-    assert get_config("mystage:mystage03") == {"parent": {"foo": "input/A.txt"}, "other": "rocket"}
+    assert get_config("mystage:mystage01") == {"parent": {"foo": foo, "bar": bar}, "param": 42}
+    assert get_config("mystage:mystage02") == {"parent": {"foo": foo}, "param": 42}
+    assert get_config("mystage:mystage03") == {"parent": {"foo": foo}, "other": "rocket"}
 
 
 def test_get_config_order(dso_project):


### PR DESCRIPTION
## Summary
This PR improves Windows compatibility while preserving POSIX behavior (#152):

- `dso compile-config` now emits **backslashes** for `!path` entries in `params.yaml` on Windows, and forward slashes on POSIX.
- `DSO_TEMPLATE_LIBRARIES` supports absolute Windows paths with drive letters (no accidental split on `C:`).
- Template rendering writes **UTF-8** with **LF** line endings and a final newline to satisfy `pre-commit` checks.
- `find_in_parent` no longer recurses past Windows drive/UNC roots.


## Rationale
Windows users encountered:
- Compiled `params.yaml` using forward slashes.
- `pre-commit` failures due to mixed line endings in generated files.
- Occasional `RecursionError` when searching above drive roots.
- Inability to include absolute Windows paths in `DSO_TEMPLATE_LIBRARIES`.


## Changes
- **`src/dso/_compile_config.py`**  
  Normalize compiled `!path` strings to OS-native separators for both relative and absolute cases.
- **`src/dso/_templates.py`**  
  - Windows-aware parsing of `DSO_TEMPLATE_LIBRARIES` that tolerates `X:\...` entries.  
  - `_copy_with_render` writes files with `encoding="utf-8"`, **LF** newlines, and a trailing newline.
- **`src/dso/_util.py`**  
  Robust root detection in `_find_in_parent_abs`: stops at drive/UNC roots; safe recurse barrier checks.
- **Tests**  
  - **`tests/test_compile_config.py`** updated to normalize expectations with `os.path.normpath` and use UTF-8 I/O.
  - Related tests adjusted where needed to avoid hard-coding `/`.

## Backward Compatibility
- On **Windows**, `params.yaml` now contains backslashes for compiled `!path` entries. Most consumers already accept native separators; if custom tooling expects `/`, normalize via `pathlib`/`os.path`.
- No CLI/API changes; POSIX behavior unchanged.

## Testing
- Unit tests updated for cross-platform path expectations and UTF-8 I/O.
- Verified locally:
  - Windows: tests pass; no mixed line-ending failures; no recursion errors.
  - Linux/macOS: unchanged behavior; tests remain green.

## Disclaimer
Some changes have been suggested by GPT-5 and Github Copilot. Therefore, some code might not follow best-practices or can lead to issues in specific circumstances. All tests have been passed on windows, but now also need to be passed on linux. 